### PR TITLE
fix of script interruption because of asking undefined object

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -500,7 +500,7 @@ HTML;
             $applet .= <<<EOD
         ggbloaded = false;
         ggbdisplaytoggle = Y.one('#applet_container1').ancestor().siblings().pop().get('children').shift();
-        if (ggbdisplaytoggle.hasAttribute('src')) {
+        if ((typeof ggbdisplaytoggle != 'undefined') && ggbdisplaytoggle.hasAttribute('src')) {
             ggbdisplaytoggle.on('click', function () {
 EOD;
             $applet .= 'applet1 = new GGBApplet(';


### PR DESCRIPTION
If you are in all submissions overview and you click the magnifier icon to view a students submission, then the applet wasn't loaded because of a js interruption while asking an object for the src attribute.
This commit should fix it. Successfully tested in Chrome.
